### PR TITLE
add extra flags to docker build command if passed in

### DIFF
--- a/lib/steps/build.js
+++ b/lib/steps/build.js
@@ -4,6 +4,7 @@ require('colors');
 var tar = require('tar-fs');
 var fs = require('fs');
 var Network = require('../external/network.js');
+var assign = require('101/assign');
 
 var noop = function () {};
 
@@ -31,10 +32,13 @@ function Builder (steps) {
 Builder.prototype.runDockerBuild = function (cb) {
   var self = this;
   var tarStream = self._getTarStream();
-
-  self.docker.buildImage(tarStream, {
+  var opts = {
     t: process.env.RUNNABLE_DOCKERTAG
-  }, function (err, response) {
+  };
+  var extraFlags = JSON.parse(process.env.RUNNABLE_BUILD_FLAGS || '{}');
+  assign(opts, extraFlags);
+
+  self.docker.buildImage(tarStream, opts, function (err, response) {
     if (err) { return cb(err); }
     self._handleBuild(response, cb);
   });

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "test"
   },
   "dependencies": {
+    "101": "^0.16.1",
     "async": "0.9.0",
     "aws-sdk": "2.0.17",
     "callback-count": "^0.1.0",

--- a/test/unit/build.js
+++ b/test/unit/build.js
@@ -83,7 +83,7 @@ lab.experiment('build.js unit test', function () {
         if (err) { return done(err); }
         expect(build._getTarStream.calledOnce).to.be.true();
         expect(build.docker.buildImage
-          .calledWith(defaultOps.dirs.dockerContext, 
+          .calledWith(defaultOps.dirs.dockerContext,
             { t: process.env.RUNNABLE_DOCKERTAG })).to.be.true();
         expect(build._handleBuild
           .calledWith(testRes)).to.be.true();
@@ -91,6 +91,37 @@ lab.experiment('build.js unit test', function () {
         build._getTarStream.restore();
         build.docker.buildImage.restore();
         build._handleBuild.restore();
+        done();
+      });
+    });
+    lab.it('should call buildImage with extra flags', function (done) {
+      process.env.RUNNABLE_BUILD_FLAGS = JSON.stringify({
+        testFlag: 'dockerTestArgs',
+        cpus: 100,
+      });
+      var build = new Builder(defaultOps);
+      var testRes = 'some string';
+
+      sinon.stub(build, '_getTarStream').returns(defaultOps.dirs.dockerContext);
+      sinon.stub(build.docker, 'buildImage').yields(null, testRes);
+      sinon.stub(build, '_handleBuild').yields();
+
+      build.runDockerBuild(function(err) {
+        if (err) { return done(err); }
+        expect(build._getTarStream.calledOnce).to.be.true();
+        expect(build.docker.buildImage
+          .calledWith(defaultOps.dirs.dockerContext, {
+            t: process.env.RUNNABLE_DOCKERTAG,
+            cpus: 100,
+            testFlag: 'dockerTestArgs'
+          })).to.be.true();
+        expect(build._handleBuild
+          .calledWith(testRes)).to.be.true();
+
+        build._getTarStream.restore();
+        build.docker.buildImage.restore();
+        build._handleBuild.restore();
+        delete process.env.RUNNABLE_BUILD_FLAGS;
         done();
       });
     });
@@ -103,7 +134,7 @@ lab.experiment('build.js unit test', function () {
       build.runDockerBuild(function(err) {
         expect(build._getTarStream.calledOnce).to.be.true();
         expect(build.docker.buildImage
-          .calledWith(defaultOps.dirs.dockerContext, 
+          .calledWith(defaultOps.dirs.dockerContext,
             { t: process.env.RUNNABLE_DOCKERTAG })).to.be.true();
 
         build._getTarStream.restore();


### PR DESCRIPTION
we want to be able to limit cpu/ram for build containers 
also allows us to add more in the future.
