### PR TITLE
Add prune when fetching

### DIFF
--- a/lib/steps.js
+++ b/lib/steps.js
@@ -239,7 +239,8 @@ var steps = module.exports = {
                   },
                   function updateCachedRepo (cb) {
                     if (fetchAndCheckout) {
-                      childProcess.execFile('git', ['fetch', '--all'],
+                      childProcess.execFile('git',
+                        ['fetch', '--prune', '--all'],
                         {
                           cwd: repoCacheDir,
                           maxBuffer: 1024 * 5000

--- a/test/steps/getRepositories.js
+++ b/test/steps/getRepositories.js
@@ -185,7 +185,7 @@ lab.experiment('getRepositories', function () {
             ['clone', '-q', sinon.match.string]))
             .to.be.false();
           expect(childProcess.execFile.calledWithMatch('git',
-            ['fetch', '--all']))
+            ['fetch', '--prune', '--all']))
             .to.be.true();
           expect(childProcess.execFile.calledWithMatch('cp')).to.be.true();
           expect(lockfile.lock.calledOnce).to.be.true();
@@ -212,6 +212,7 @@ lab.experiment('getRepositories', function () {
               'git',
               [
                 'fetch',
+                '--prune',
                 '--all'
               ]
             );


### PR DESCRIPTION
### What this does
- Prunes non-existing branches before fetching them
### Tests
- [x] Run test specified here: https://runnable.atlassian.net/browse/SAN-1595
- [x] Make sure fetching works correctly
- [x] Test git submodules
### Reviewers
- [x] @bkendall 
- [x] @anandkumarpatel 
### Integration Test
- [x] Integration Tested @ `4fcad460c1c302b67b3aa142f5e1f9d29c9d2529` by `snoop` on `gamma`
